### PR TITLE
Fix unit tests

### DIFF
--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -1,7 +1,7 @@
 module "test_alerts" {
   source                    = "../../"
   sns_topics                = [aws_sns_topic.test_alarms.name]
-  pagerduty_integration_key = local.pagerduty_integration_keys["low_priority_alarms"]
+  pagerduty_integration_key = local.pagerduty_integration_keys["test_alarms"]
   depends_on                = [aws_sns_topic.test_alarms]
 }
 


### PR DESCRIPTION
We've changed the pagerduty services, but are still referring to the old integration key in our unit tests.
This PR updates the unit tests to a new key.