### PR TITLE
update documentation.yml action

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,8 +5,15 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
+
 jobs:
   docs:
+    permissions:
+      pull-requests: write
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2


### PR DESCRIPTION
The `documentation.yml` is causing a secure code analysis failure. This PR updates the action to use the same configuration we supply from [Modernisation Platform Terraform Module Template](github.com/ministryofjustice/modernisation-platform-terraform-module-template/).