### PR TITLE
AWS Provider 5.0 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If you're looking to raise an issue with this module, please create a new issue 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 

--- a/test/unit-test/versions.tf
+++ b/test/unit-test/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }


### PR DESCRIPTION
Bumps version constraint to ~> 5.0.
Related to https://github.com/ministryofjustice/modernisation-platform/issues/4173