### PR TITLE
Pipe Exit Status

### DIFF
--- a/.github/workflows/go-terratest.yml
+++ b/.github/workflows/go-terratest.yml
@@ -29,4 +29,5 @@ jobs:
         working-directory: test
         run: |
           chmod 700 ../scripts/redact-output.sh
-          go test -v | ../scripts/redact-output.sh
+          go test -v | tee >(../scripts/redact-output.sh)
+          exit ${PIPESTATUS[0]}


### PR DESCRIPTION
This PR updates the go-terratest workflow to correctly handle the exit status of the go-test command. Due to the usage of the pipe (|) with redact-output.sh, the exit status of the last command in the pipe is returned, which in this case is the script redact-output.sh. If redact-output.sh does not correctly propagate the exit status of go-test, the workflow is reporting success even when tests fail.

```yaml
- name: Run Go Tests
  working-directory: test
  run: |
    chmod 700 ../scripts/redact-output.sh
    go test -v | tee >(../scripts/redact-output.sh)
    exit ${PIPESTATUS[0]}
```