### PR TITLE
Update README to use new GitHub-Community repository-standards badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ No modules.
 | <a name="output_sns_topic_arn"></a> [sns\_topic\_arn](#output\_sns\_topic\_arn) | n/a |
 <!-- END_TF_DOCS -->
 
-[Standards Link]: https://github-community.cloud-platform.service.justice.gov.uk/repository-standards/modernisation-platform-terraform-pagerduty-integration 'Repo standards badge.'
-[Standards Icon]: https://github-community.cloud-platform.service.justice.gov.uk/repository-standards/api/modernisation-platform-terraform-pagerduty-integration/badge
+[Standards Link]: https://github-community.service.justice.gov.uk/repository-standards/modernisation-platform-terraform-pagerduty-integration 'Repo standards badge.'
+[Standards Icon]: https://github-community.service.justice.gov.uk/repository-standards/api/modernisation-platform-terraform-pagerduty-integration/badge
 [Format Code Icon]: https://img.shields.io/github/actions/workflow/status/ministryofjustice/modernisation-platform-terraform-pagerduty-integration/format-code.yml?labelColor=231f20&style=for-the-badge&label=Formate%20Code
 [Format Code Link]: https://github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration/actions/workflows/format-code.yml
 [Scorecards Icon]: https://img.shields.io/github/actions/workflow/status/ministryofjustice/modernisation-platform-terraform-pagerduty-integration/scorecards.yml?branch=main&labelColor=231f20&style=for-the-badge&label=Scorecards


### PR DESCRIPTION
This PR updates the README to use the new GitHub-Community repository-standards badge as per announcement: https://mojdt.slack.com/archives/C05L0KBA7RS/p1742897064793689